### PR TITLE
Replaced '&' with 'and', and 'Uv indes' with 'UV index'

### DIFF
--- a/language/English/strings.xml
+++ b/language/English/strings.xml
@@ -70,7 +70,7 @@
     
     <!-- OSD -->
     <string id="41240">Enable music visualisation</string>
-    <string id="41241">Hide power button, weather & clock in music osd (recommended for plasma tv's)</string>
+    <string id="41241">Hide power button, weather and clock in music osd (recommended for plasma tv's)</string>
     
     <!-- Backgrounds -->
     <string id="41250">Backgrounds</string>
@@ -99,14 +99,14 @@
     <string id="41285">Enable TV Show Next Aired</string>
     <string id="41286">Download 16:9 tv show thumbs for tv guide</string>
     <string id="41287">Enable extra fanart</string>
-    <string id="41288">Download extra fanarts for movies & tv shows</string>
+    <string id="41288">Download extra fanarts for movies and tv shows</string>
     <string id="41289">Configure Artwork Downloader</string>
     <string id="41290">Configure TV Show Next Aired</string>
     <string id="41291">Disable watch list (needs restart to take effect)</string>
     <string id="41292">Disable random items (needs restart to take effect)</string>
     <string id="41293">Update next aired data on startup</string>
     
-    <!-- DialogAlbumInfo.XML & DialogVideoInfo.XML -->
+    <!-- DialogAlbumInfo.XML and DialogVideoInfo.XML -->
     <!-- From 41300 to 41349 -->
     <string id="41300">Style: </string>
     <string id="41301">Mood: </string>
@@ -158,7 +158,7 @@
     <string id="41359">Eject/Load</string>
     <string id="41360">Master mode</string>
     
-    <!-- DialogSeekBar.xml & VideoOSD.xml -->
+    <!-- DialogSeekBar.xml and VideoOSD.xml -->
     <!-- From 41370 to 41399 -->
     <string id="41370">Current time:</string>
     <string id="41371">Finish time:</string>    
@@ -292,7 +292,7 @@
     <string id="41682">Feels like</string>      
     <string id="41683">Dew point</string>       
     <string id="41684">Humidity</string>        
-    <string id="41685">Uv indes</string>        
+    <string id="41685">UV index</string>        
     <string id="41686">Wind</string>        
     <string id="41687">High</string>        
     <string id="41688">Low</string> 


### PR DESCRIPTION
'&' has speciall meaning in XML and should be written as '&amp;' when used in a string. However, I replaced '&' with 'and' instead as it's stylistically preferred in most situations.

Also changed 'Uv indes' to 'UV index'.
