### PR TITLE
Fix include conditions for music visualisation.

### DIFF
--- a/1080i/Includes_WindowContents.xml
+++ b/1080i/Includes_WindowContents.xml
@@ -30,8 +30,8 @@
         <include>CommonStage</include>
     </include>
     <include name="CommonItemsMusicOSD">
-        <include condition="!Skin.HasSetting(OSDBackground.Disabled)">CommonContent</include>
-        <include condition="!Skin.HasSetting(OSDBackground.Disabled)">BackgroundFanartMusicOSD</include>
+        <include condition="!Skin.HasSetting(OSDVisualisation.Enabled)">CommonContent</include>
+        <include condition="!Skin.HasSetting(OSDVisualisation.Enabled) + Skin.HasSetting(ArtistSlideShow)">BackgroundFanartMusicOSD</include>
         <include condition="Skin.HasSetting(OSDVisualisation.Enabled)">OSDVisualisation</include>
         <control type="image">
             <animation effect="slide" end="0" time="0" delay="400">WindowClose</animation>


### PR DESCRIPTION
Multiple backgrounds were being loaded when showing the music visualisation. The corrected conditions mean only one should show at a time. (Common, Fanart or Visualisation.)
