### PR TITLE
Add option to disable metro background overlay.

### DIFF
--- a/1080i/Custom_Settings.xml
+++ b/1080i/Custom_Settings.xml
@@ -417,6 +417,15 @@
                     <onclick>ReloadSkin()</onclick>
                     <label>$LOCALIZE[41155]</label>
                 </control>
+                <control type="radiobutton" id="2008">
+                    <width>1210</width>
+                    <include>SettingsCategoryRadioButtonVars</include>
+                    <selected>Skin.HasSetting(HomeMetroOverlay.Disabled)</selected>
+                    <onclick>Skin.ToggleSetting(HomeMetroOverlay.Disabled)</onclick>
+                    <label>$LOCALIZE[41161]</label>
+                    <enable>Skin.HasSetting(HomeNew.Enabled)</enable>
+                    <animation effect="fade" start="100" end="42" time="0" condition="!Skin.HasSetting(HomeNew.Enabled)">Conditional</animation>
+                </control>
                 <control type="button" id="2001">
                     <width>1210</width>
                     <texturefocus border="150,1,150,1">windows/settings/images/right-focus-arrow-fo.png</texturefocus>

--- a/1080i/Includes_WindowContents.xml
+++ b/1080i/Includes_WindowContents.xml
@@ -130,6 +130,7 @@
             <animation effect="fade" time="300" start="0" end="100" tween="sine" easing="out">Visible</animation>
             <animation effect="fade" time="300" start="100" end="0" tween="sine" easing="in">Hidden</animation>
             <visible>IsEmpty(Skin.String(stage.customImage)) + !Window.IsVisible(script-globalsearch-infodialog.xml) + Skin.HasSetting(HomeNew.Enabled)</visible>
+            <visible>!Skin.HasSetting(HomeMetroOverlay.Disabled)</visible>
         </control>
         <control type="image">
             <include>FullscreenDimensions</include>
@@ -139,6 +140,7 @@
             <animation effect="fade" time="300" start="0" end="95" tween="sine" easing="out">Visible</animation>
             <animation effect="fade" time="300" start="95" end="0" tween="sine" easing="in">Hidden</animation>
             <visible>!IsEmpty(Skin.String(stage.customImage)) + !Window.IsVisible(script-globalsearch-infodialog.xml) + Skin.HasSetting(HomeNew.Enabled)</visible>
+            <visible>!Skin.HasSetting(HomeMetroOverlay.Disabled)</visible>
         </control>
     </include>
 

--- a/language/English/strings.xml
+++ b/language/English/strings.xml
@@ -50,6 +50,7 @@
     <string id="41158">TV Show tile</string>
     <string id="41159">App tile</string>
     <string id="41160">Animate icon</string>
+    <string id="41161">Hide metro background</string>
     
     <!-- Views -->
     <string id="41190">Views</string>


### PR DESCRIPTION
The white or black overlay is a large texture and can hurt performance on slower systems.

Added an option to disable it under the Home settings screen.
