### PR TITLE
PVRChannelsOSD: added commands for switching channel group (left/right)

### DIFF
--- a/1080i/DialogPVRChannelsOSD.xml
+++ b/1080i/DialogPVRChannelsOSD.xml
@@ -35,7 +35,7 @@
                     <posy>124</posy>
                     <width>680</width>
                     <height>761</height>
-                    <onleft>60</onleft>
+                    <onleft>PreviousChannelGroup</onleft>
                     <onright>60</onright>
                     <onup>11</onup>
                     <ondown>11</ondown>
@@ -345,7 +345,7 @@
                     <width>11</width>
                     <height>741</height>
                     <onleft>11</onleft>
-                    <onright>11</onright>
+                    <onright>NextChannelGroup</onright>
                     <texturesliderbar border="0,6,0,6">views/other/scrollbar.png</texturesliderbar>
                     <texturesliderbarfocus border="0,6,0,6">views/other/scrollbar.png</texturesliderbarfocus>
                     <orientation>vertical</orientation>


### PR DESCRIPTION
This PR is in preparation for PR #2246 which replace hardcoded
left/right group switching in PVRChannelsOSD.

The changes can be merged immediately, but will have no effect until the changes were adopted from #2246 to the XBMC master.
