### PR TITLE
Remove condition on OSDChaperInfo Include

### DIFF
--- a/1080i/DialogSeekBar.xml
+++ b/1080i/DialogSeekBar.xml
@@ -3,7 +3,7 @@
     <visible>Window.IsActive(fullscreenvideo) + [Player.ShowInfo | Player.Seeking | Player.DisplayAfterSeek | Player.Paused | Player.Forwarding | Player.Rewinding | Window.IsActive(videoosd) | Window.IsVisible(fullscreeninfo)] + !Window.IsVisible(sliderdialog) + ![!Window.IsActive(videoosd) + [Window.IsActive(script-XBMC-Subtitles-main.xml) | Window.IsActive(pvrguideinfo) | Window.IsActive(pvrosdchannels) | Window.IsActive(pvrosdguide) | Window.IsActive(yesnodialog) | Window.IsActive(okdialog) | Window.IsActive(progressdialog) | Window.IsActive(virtualkeyboard) | Window.IsActive(numericinput) | Window.IsActive(shutdownmenu) | Window.IsActive(osdvideosettings) | Window.IsActive(osdaudiosettings) | Window.IsActive(videobookmarks)]]</visible>
     <controls>
         <include>OSDWeatherClock</include>
-        <include condition="VideoPlayer.Content(Movies)">OSDChapterInfo</include>
+        <include>OSDChapterInfo</include>
         <control type="group">
             <animation type="WindowOpen">
                 <effect type="fade" start="0" end="100" time="200" tween="sine" easing="inout" />


### PR DESCRIPTION
I've been meaning to look into why this skin didn't support chapters, only to realize after looking back through the git log that chapters have been supported for nearly a year, but _only for movie items_.

Since I haven't actually watched any movies with chapters, but watch lots of anime with chapters this is frustrating.

This removes the condition. Perhaps there was a reason for it though?
